### PR TITLE
Weaken optional tool requirements.

### DIFF
--- a/libstorage.spec.in
+++ b/libstorage.spec.in
@@ -107,8 +107,9 @@ rm -rf "$RPM_BUILD_ROOT"
 
 %package -n libstorage@LIBVERSION_MAJOR@
 
-Requires:       parted >= 2.2 mdadm device-mapper lvm2 dmraid multipath-tools cryptsetup
-Requires:       coreutils udev util-linux >= 2.16 grep lsscsi
+Requires:       parted >= 2.2 device-mapper
+Recommends:     lvm2 dmraid mdadm multipath-tools cryptsetup lsscsi
+Requires:       coreutils udev util-linux >= 2.16 grep
 %ifarch s390 s390x
 Requires:       s390-tools
 %endif


### PR DESCRIPTION
Instead of 'Requires' on every storage solution under the sun, a 'Recommends' is sufficient. This way you'll still get it at install time, _but_ the user has the option to actually deinstall it if not neeeded. You would want to do this to improve boot times on end-user hardware, see http://lizards.opensuse.org/2012/07/26/optimizing-a-boot-time-aka-2-second-boot/

dmraid / mdraid: Usually, you only need one
multipath-tools: Only needed if you actually have suitable devices
cryptsetup: Only if you use LUKS, ...
lvm2: No logical volumes, no need
lsscsi: Not entirely sure about this one, end-user hardware usually uses SATA
