### PR TITLE
Always wipe PReP partition

### DIFF
--- a/package/libstorage.changes
+++ b/package/libstorage.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Apr  7 19:43:18 UTC 2014 - dvaleev@suse.com
+
+- Always wipe PReP partition (bnc#870590)
+
+-------------------------------------------------------------------
 Tue Mar 25 16:58:09 CET 2014 - aschnell@suse.de
 
 - fixed type visibility for gcc 4.9

--- a/storage/Partition.cc
+++ b/storage/Partition.cc
@@ -387,13 +387,16 @@ Partition::zeroIfNeeded() const
 
     bool zero_new = getContainer()->getStorage()->getZeroNewPartitions();
     bool used_as_pv = isUsedBy(UB_LVM);
+    bool prep = id() == ID_PPC_PREP;
 
-    y2mil("zero_new:" << zero_new << " used_as_pv:" << used_as_pv);
+    y2mil("zero_new:" << zero_new << " used_as_pv:" << used_as_pv << " prep:" << prep);
 
-    if (zero_new || used_as_pv)
-    {
-       ret = getContainer()->getStorage()->zeroDevice(device());
-    }
+   if (prep) {
+       ret = getContainer()->getStorage()->zeroDevice(device(), false, size_k);
+   } else {
+       if (zero_new || used_as_pv)
+          ret = getContainer()->getStorage()->zeroDevice(device());
+       }
 
     return ret;
 }


### PR DESCRIPTION
grub2-install is able install stage1 binary only to either empty partition or
partition with stage1's ELF.

Make sure we're wiping PReP partition all the time.

Signed-off-by: Dinar Valeev dvaleev@suse.com
