### PR TITLE
configure uses python2-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,8 +29,14 @@ dnl Automake 1.11 enables silent compilation
 dnl Disable it by "configure --disable-silent-rules" or "make V=1"
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-CFLAGS="${CFLAGS} -Wall -Wformat=2 -Wmissing-prototypes"
-CXXFLAGS="${CXXFLAGS} -std=c++0x -DHAVE_CXX0X -Wall -Wextra -Wformat=2 -Wnon-virtual-dtor -Wno-unused-parameter"
+PYTHON_CONFIG=${PYTHON_CONFIG:-python2-config}
+PYTHON_INCLUDES=$($PYTHON_CONFIG --includes)
+PYTHON_LIBS=$($PYTHON_CONFIG --libs)
+
+CFLAGS="${CFLAGS} -Wall -Wformat=2 -Wmissing-prototypes $PYTHON_INCLUDES"
+CXXWARNS="-Wall -Wextra -Wformat=2 -Wnon-virtual-dtor -Wno-unused-parameter"
+CXXFLAGS="${CXXFLAGS} -std=c++0x -DHAVE_CXX0X $CXXWARNS $PYTHON_INCLUDES"
+LIBS="$LIBS $PYTHON_LIBS"
 
 docdir=\${prefix}/share/doc/packages/libstorage
 fillupdir=/var/adm/fillup-templates

--- a/package/libstorage.changes
+++ b/package/libstorage.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jul 07 13:31:30 CEST 2014 - rneuhauser@sigpipe.cz
+
+- configure{,.ac} uses python2-config to find python headers, libs
+
+-------------------------------------------------------------------
 Wed Jun 11 13:11:19 CEST 2014 - dvaleev@suse.com
 
 - Print different messages for msdos and gpt PReP partitions


### PR DESCRIPTION
i have an archlinux box with python-{2.7,3.4} installed (including
development files), and the python bindings for libstorage failed
to build because neither python package puts Python.h where
libstorage expects it.

double-checked on openSUSE-13.1.
