### PR TITLE
fix a potential segfault in LvmVg::doCreate

### DIFF
--- a/storage/LvmVg.cc
+++ b/storage/LvmVg.cc
@@ -1687,7 +1687,7 @@ LvmVg::doCreate( Volume* v )
             if( !orig || !orig->isThin() )
                 cmd += " -l " + decString(l->getLe());
             if( l->chunkSize()>0 )
-                cmd += " --chunksize " + l->chunkSize();
+                cmd += " --chunksize " + decString(l->chunkSize());
             cmd += " --snapshot";
             cmd += " --name " + quote(l->name());
             cmd += " " + quote(name() + "/" + l->getOrigin());


### PR DESCRIPTION
actual effects depend on l->chunkSize()

```
LvmVg.cc:1677:40: warning: adding 'unsigned long long' to a string does not append to the string
      [-Wstring-plus-int]
                cmd += " --chunksize " + l->chunkSize();
                       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
LvmVg.cc:1677:40: note: use array indexing to silence this warning
                cmd += " --chunksize " + l->chunkSize();
                                       ^
                       &               [               ]
```
