### PR TITLE
CXXWARNS includes -Wno-overloaded-virtual

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ PYTHON_INCLUDES=$($PYTHON_CONFIG --includes)
 PYTHON_LIBS=$($PYTHON_CONFIG --libs)
 
 CFLAGS="${CFLAGS} -Wall -Wformat=2 -Wmissing-prototypes $PYTHON_INCLUDES"
-CXXWARNS="-Wall -Wextra -Wformat=2 -Wnon-virtual-dtor -Wno-unused-parameter"
+CXXWARNS="-Wall -Wextra -Wformat=2 -Wnon-virtual-dtor -Wno-overloaded-virtual -Wno-unused-parameter"
 CXXFLAGS="${CXXFLAGS} -std=c++0x -DHAVE_CXX0X $CXXWARNS $PYTHON_INCLUDES"
 LIBS="$LIBS $PYTHON_LIBS"
 


### PR DESCRIPTION
clang++ spews out a lot of warnings like these:

```
  In file included from ../storage/Storage.h:38:
  In file included from ../storage/LvmVg.h:26:
  ../storage/PeContainer.h:63:7: warning: 'storage::PeContainer::equalContent' hides overloaded virtual function [-Woverloaded-virtual]
          bool equalContent( const PeContainer& rhs, bool comp_vol=true ) const;
               ^
  ../storage/Container.h:71:15: note: hidden overloaded virtual function 'storage::Container::equalContent' declared here: different number of parameters (1 vs 2)
          virtual bool equalContent( const Container& rhs ) const;
                       ^
  In file included from Storage.cc:39:
  In file included from ../storage/Storage.h:51:
  ../storage/BtrfsCo.h:69:6: warning: 'storage::BtrfsCo::resizeVolume' hides overloaded virtual function [-Woverloaded-virtual]
          int resizeVolume( Volume* v, Container* r_co, Volume* r_v,
              ^
  ../storage/Container.h:182:14: note: hidden overloaded virtual function 'storage::Container::resizeVolume' declared here: different number of parameters (2 vs 4)
          virtual int resizeVolume( Volume* v, unsigned long long newSize );
                      ^
```

while the warnings point out a real (if only potentially) problem
with the code, i'm not ready to tackle it, and the warnings clutter
compiler output obscuring other messages i care about at the moment.
