### PR TITLE
silence struct/class decl/def mismatch warnings

### DIFF
--- a/storage/Storage.h
+++ b/storage/Storage.h
@@ -195,7 +195,7 @@ class CastCheckFncIterator : public FilterIterator< CheckByFnc<FncP>, Iter >
 
 class EtcFstab;
     class EtcMdadm;
-class DiskData;
+struct DiskData;
 
 
     /**

--- a/storage/Volume.h
+++ b/storage/Volume.h
@@ -39,9 +39,9 @@ namespace storage
 class SystemCmd;
 class ProcMounts;
 class EtcFstab;
-class FstabEntry;
-class FstabChange;
-class FstabKey;
+struct FstabEntry;
+struct FstabChange;
+struct FstabKey;
 class Container;
 class Storage;
 


### PR DESCRIPTION
```
Storage.cc:692:1: warning: 'DiskData' defined as a struct here but previously declared as a class [-Wmismatched-tags]
struct DiskData
^
../storage/Storage.h:198:1: note: did you mean struct here?
class DiskData;
^~~~~
struct
```
