### PR TITLE
Documented + improved error reporting for CmdBtrfs

### DIFF
--- a/storage/SystemInfo/CmdBtrfs.h
+++ b/storage/SystemInfo/CmdBtrfs.h
@@ -36,14 +36,37 @@ namespace storage
     using std::map;
 
 
+    /**
+     * Class to probe for btrfs filesystems: Call "btrfs filesystem show"
+     * (globally, not restricted to any disk or partition) and parse its
+     * output.
+     */
     class CmdBtrfsShow
     {
     public:
 
-	CmdBtrfsShow(bool do_probe = true);
+	/**
+	 * Constructor. If 'do_probe' is 'true', call "btrfs filesystem show"
+	 * as an external command. If 'do_probe' is 'false', do nothing for now
+	 * (this is mostly useful for testing).
+	 *
+	 * This may throw a SystemCmdException or a ParseException.
+	 */
+	CmdBtrfsShow( bool do_probe = true );
 
+	/**
+	 * Probe for btrfs filesystems with the "btrfs filesystem show" command
+	 * and parse its output.
+	 *
+	 * This may throw a SystemCmdException or a ParseException.
+	 */
 	void probe();
 
+	/**
+	 * Entry for one btrfs filesystem. Since btrfs includes a volume
+	 * manager (independent of LVM or the device mapper), this may be
+	 * multiple devices for a single btrfs filesystem.
+	 */
 	struct Entry
 	{
 	    list<string> devices;
@@ -52,11 +75,24 @@ namespace storage
 	friend std::ostream& operator<<(std::ostream& s, const CmdBtrfsShow& cmdbtrfsshow);
 	friend std::ostream& operator<<(std::ostream& s, const Entry& entry);
 
-	bool getEntry(const string& uuid, Entry& entry) const;
+	/**
+	 * Find the btrfs filesystem with UUID 'uuid' and return the
+	 * corresponding entry in 'entry'. Return 'true' upon success, 'false'
+	 * if there is no btrfs filesystem with that UUID.
+	 */
+	bool getEntry( const string& uuid, Entry& entry ) const;
 
+	/**
+	 * Return a list of all filesystem UUIDs with btrfs.
+	 */
 	list<string> getUuids() const;
 
-	void parse(const vector<string>& lines);
+	/**
+	 * Parse the output of "btrfs filesystem show" passed in 'lines'.
+	 *
+	 * This may throw a ParseException.
+	 */
+	void parse( const vector<string>& lines );
 
     private:
 

--- a/testsuite/btrfs.cc
+++ b/testsuite/btrfs.cc
@@ -4,6 +4,7 @@
 #include "common.h"
 
 #include "storage/SystemInfo/CmdBtrfs.h"
+#include "storage/Exception.h"
 
 
 using namespace std;
@@ -11,9 +12,9 @@ using namespace storage;
 
 
 void
-parse1()
+parse_good()
 {
-    cout << "parse1" << endl;
+    TRACE();
 
     vector<string> lines = {
 	"Label: none  uuid: ea108250-d02c-41dd-b4d8-d4a707a5c649",
@@ -31,10 +32,80 @@ parse1()
 	"Btrfs v3.12+20131125"
     };
 
-    CmdBtrfsShow cmdbtrfsshow(false);
-    cmdbtrfsshow.parse(lines);
+    CmdBtrfsShow cmd( false );
+    cmd.parse( lines );
 
-    cout << cmdbtrfsshow << endl;
+    cout << cmd << endl;
+}
+
+
+void
+parse_empty()
+{
+    TRACE();
+
+    // Sample output if there is no btrfs filesystem at all on the system
+    vector<string> lines = {
+	"Btrfs v3.12+20131125"
+    };
+
+    CmdBtrfsShow cmd( false );
+    cmd.parse( lines );
+
+    cout << cmd << endl;
+}
+
+
+void
+parse_bad_device_name()
+{
+    TRACE();
+
+    vector<string> lines = {
+	"Label: none  uuid: ea108250-d02c-41dd-b4d8-d4a707a5c649",
+	"        Total devices 1 FS bytes used 28.00KiB",
+	"        devid    1 size 1.00GiB used 138.38MiB path notadevicename", // no /dev/...
+	"",
+	"Btrfs v3.12+20131125"
+    };
+
+    try
+    {
+	CmdBtrfsShow cmd( false );
+	cmd.parse( lines );
+	EXCEPTION_EXPECTED();
+    }
+    catch ( const ParseException &ex )
+    {
+	ST_CAUGHT( ex );
+	cout << "CAUGHT EXCEPTION (expected): " << ex << endl;
+    }
+}
+
+
+void
+parse_no_devices()
+{
+    TRACE();
+
+    vector<string> lines = {
+	"Label: none  uuid: ea108250-d02c-41dd-b4d8-d4a707a5c649",
+	"        Total devices 1 FS bytes used 28.00KiB",
+	"",
+	"Btrfs v3.12+20131125"
+    };
+
+    try
+    {
+	CmdBtrfsShow cmd( false );
+	cmd.parse( lines );
+	EXCEPTION_EXPECTED();
+    }
+    catch ( const ParseException &ex )
+    {
+	ST_CAUGHT( ex );
+	cout << "CAUGHT EXCEPTION (expected): " << ex << endl;
+    }
 }
 
 
@@ -45,5 +116,8 @@ main()
 
     setup_logger();
 
-    parse1();
+    parse_good();
+    parse_empty();
+    parse_bad_device_name();
+    parse_no_devices();
 }

--- a/testsuite/common.cc
+++ b/testsuite/common.cc
@@ -7,6 +7,7 @@
 
 #include "storage/Utils/AppUtil.h"
 #include "storage/Utils/Region.h"
+#include "storage/Exception.h"
 
 
 extern char* program_invocation_short_name;
@@ -131,5 +132,15 @@ namespace storage
 
 	cout << endl;
     }
+}
 
+
+std::ostream & operator<<( std::ostream & stream, const storage::ParseException & ex )
+{
+    stream << "ParseException: " << ex.msg()
+	   << "\n  seen:     \"" << ex.seen()     << "\""
+	   << "\n  expected: \"" << ex.expected() << "\""
+	   << std::endl;
+
+    return stream;
 }

--- a/testsuite/common.h
+++ b/testsuite/common.h
@@ -1,12 +1,19 @@
 
+#include <iosfwd>
 #include <storage/StorageInterface.h>
 
 
 #define TRACE() cout << "### " << __FUNCTION__ << "()" << endl
 
+#define EXCEPTION_EXPECTED() \
+    cout << "\n*** " << __FILE__ << "(" << __FUNCTION__ << "):" << __LINE__ << ": " \
+    << "EXPECTED EXCEPTION NOT CAUGHT! ***\n\n" << endl;
+
 
 namespace storage
 {
+    class ParseException;
+
     void setup_logger();
 
     void setup_system(const string& name);
@@ -32,3 +39,5 @@ namespace storage
     };
 
 }
+
+std::ostream & operator<<( std::ostream & stream, const storage::ParseException & ex );

--- a/testsuite/parted.cc
+++ b/testsuite/parted.cc
@@ -11,23 +11,6 @@ using namespace std;
 using namespace storage;
 
 
-#define EXCEPTION_EXPECTED() \
-    cout << "\n*** " << __FILE__ << "(" << __FUNCTION__ << "):" << __LINE__ << ": " \
-    << "EXPECTED EXCEPTION NOT CAUGHT! ***\n\n" << endl;
-
-
-ostream & operator<<( ostream & stream, const ParseException & ex )
-{
-    stream << "ParseException: " << ex.msg()
-	   << "\n  seen:     \"" << ex.seen()     << "\""
-	   << "\n  expected: \"" << ex.expected() << "\""
-	   << endl;
-
-    return stream;
-}
-
-
-
 void
 parse_msdos_disk_label_good()
 {

--- a/testsuite/single.out/btrfs.out
+++ b/testsuite/single.out/btrfs.out
@@ -1,5 +1,17 @@
-parse1
+### parse_good()
 data[653764e0-7ea2-4dbe-9fa1-866f3f7783c9] -> </dev/mapper/system-btrfs>
 data[d82229f2-f9e4-40fd-b15f-84e2d42e6d0d] -> </dev/mapper/system-testsuite>
 data[ea108250-d02c-41dd-b4d8-d4a707a5c649] -> </dev/mapper/system-test>
+
+### parse_empty()
+
+### parse_bad_device_name()
+CAUGHT EXCEPTION (expected): ParseException: Not a valid device name
+  seen:     "notadevicename"
+  expected: "/dev/..."
+
+### parse_no_devices()
+CAUGHT EXCEPTION (expected): ParseException: No devices for UUID ea108250-d02c-41dd-b4d8-d4a707a5c649
+  seen:     ""
+  expected: "devid  1 size 40.00GiB used 16.32GiB path /dev/sda2"
 


### PR DESCRIPTION
- Use exceptions for CmdBtrfs
- Documented CmdBtrfs
- Added sanity checks:
  - device name must contain "/dev"
 - each btrfs file system must have at least one device
- New test cases for parse errors