### PR TITLE
Allow unrecognized disk label (new virtual disk etc.)

### DIFF
--- a/storage/SystemInfo/CmdParted.cc
+++ b/storage/SystemInfo/CmdParted.cc
@@ -52,7 +52,11 @@ namespace storage
 	// partition table is found.
 
 	if ( !cmd.stderr().empty() )
-	    ST_THROW( SystemCmdException( &cmd, "parted complains: " + cmd.stderr().front() ) );
+	{
+	    // suppress complaints about "unrecognised disk label" (might be an empty disk)
+	    if ( ! boost::ends_with( cmd.stderr().front(), "unrecognised disk label" ) )
+		ST_THROW( SystemCmdException( &cmd, "parted complains: " + cmd.stderr().front() ) );
+	}
 
 	parse( cmd.stdout() );
     }


### PR DESCRIPTION
Fix for failed openQA test https://openqa.suse.de/tests/50707 : 
Unhandled exception because parted complains about "unrecognised disk label".
This may legally happen if a new disk without any disk label (e.g., a virtual disk) is probed.

Tested manually with a file created with    dd if=/dev/zero of=/tmp/empty bs=1 size=200
and tweaking the testsuite a bit.

Intentionally not including this in the testsuite because then we'd again need a BuildRequires dependency from libstorage to parted.