### PR TITLE
Use a Rakefile for packaging tasks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ Makefile.bak
 Makefile
 .deps
 .libs
-
+/.obsdir/
 aclocal.m4
 autom4te.cache
 config.*
@@ -13,6 +13,7 @@ install-sh
 libtool
 ltmain.sh
 missing
+/obs-package-from-git
 stamp-h1
 py-compile
 compile

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -1,0 +1,17 @@
+# -*- Makefile -*-
+
+# Usage in Jenkins:
+# make -f Makefile.ci package
+
+.PHONY: package
+package: obs-package-from-git
+	./$^ \
+		-P YaST:Head -p libstorage \
+		-o .obsdir \
+		-c 'make -f Makefile.repo && make package'
+
+# A script that is shared with other projects and should be always refreshed
+URL=https://raw.githubusercontent.com/openSUSE/obs-package-from-git/master/obs-package-from-git
+.PHONY: always_out_of_date
+obs-package-from-git: always_out_of_date
+	wget -O $@ $(URL) && chmod +x $@

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# make continuous integration using rubygem-packaging_rake_tasks
+# Copyright © 2015 SUSE
+# MIT license
+
+require "packaging/tasks"
+require "packaging/configuration"
+# skip 'tarball' task, it's redefined here
+Packaging::Tasks.load_tasks(:exclude => ["tarball.rake"])
+
+Packaging.configuration do |conf|
+  conf.obs_project    = "YaST:Head"
+  conf.obs_sr_project = "openSUSE:Factory"
+  conf.package_dir    = ".obsdir"
+  conf.skip_license_check << /.*/
+end
+
+desc 'Pretend to run the test suite'
+task :test do
+  puts 'No tests yet' if verbose
+end
+
+desc 'Build a tarball for OBS'
+task :tarball do
+  sh "make -f Makefile.ci package"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -8,10 +8,12 @@ require "packaging/configuration"
 # skip 'tarball' task, it's redefined here
 Packaging::Tasks.load_tasks(:exclude => ["tarball.rake"])
 
+require "yast/tasks"
+Yast::Tasks.submit_to(ENV.fetch("YAST_SUBMIT", "factory").to_sym)
+
 Packaging.configuration do |conf|
-  conf.obs_project    = "YaST:Head"
-  conf.obs_sr_project = "openSUSE:Factory"
-  conf.package_dir    = ".obsdir"
+  conf.package_name.sub!(/-.*/, "") # strip branch name
+  conf.package_dir    = ".obsdir" # Makefile.ci puts it there
   conf.skip_license_check << /.*/
 end
 


### PR DESCRIPTION
Usage in Jenkins:
```sh
cd $WORKSPACE
rake osc:build  
```

Yes, Rake (and Ruby) is foreign to C++ development. I think it is justified to introduce it for the specific task of submitting to the openSUSE Build Service, something a C++ contributor does not need but our team does.