### PR TITLE
Skip partition boot flag on 'dasd' label

### DIFF
--- a/storage/Disk.cc
+++ b/storage/Disk.cc
@@ -1846,7 +1846,8 @@ namespace storage
 		if (label == "dvh" || label == "mac")
 		    options << " set " << p->nr() << " swap " << (p->id()==Partition::ID_SWAP?"on":"off");
 
-		options << " set " << p->nr() << " boot " << ((p->boot()||p->id()==Partition::ID_GPT_BOOT)?"on":"off");
+		if (label != "dasd")
+		    options << " set " << p->nr() << " boot " << ((p->boot()||p->id()==Partition::ID_GPT_BOOT)?"on":"off");
 
 		if (label == "gpt") {
 		    options << " set " << p->nr() << " prep " << (p->id()==Partition::ID_GPT_PREP?"on":"off");


### PR DESCRIPTION
For partitions with the disk label 'dasd', there is no boot flag
available. Trying to set it with parted >= 3.1 results in an error.
So skip passing this flag to parted for the 'dasd' disk label.