### PR TITLE
Replace references to /var/adm/fillup-templates with new %_fillupdir …

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ CXXWARNS="-Wall -Wextra -Wformat=2 -Wnon-virtual-dtor -Wno-unused-parameter"
 CXXFLAGS="${CXXFLAGS} -std=c++0x -DHAVE_CXX0X ${CXXWARNS}"
 
 docdir=\${prefix}/share/doc/packages/libstorage
-fillupdir=/var/adm/fillup-templates
+fillupdir=/usr/share/fillup-templates
 
 AC_SUBST(VERSION)
 AC_SUBST(LIBVERSION)

--- a/libstorage.spec.in
+++ b/libstorage.spec.in
@@ -16,6 +16,11 @@
 #
 
 
+#Compat macro for new _fillupdir macro introduced in Nov 2017
+%if ! %{defined _fillupdir}
+  %define _fillupdir /var/adm/fillup-templates
+%endif
+
 Name:           libstorage
 Version:        @VERSION@
 Release:        0
@@ -156,7 +161,7 @@ Authors:
 %defattr(-,root,root)
 %{_libdir}/libstorage.so.*
 %ghost /run/libstorage
-/var/adm/fillup-templates/sysconfig.storage-libstorage
+%{_fillupdir}/sysconfig.storage-libstorage
 %doc %dir %{prefix}/share/doc/packages/libstorage
 %doc %{prefix}/share/doc/packages/libstorage/AUTHORS
 %doc %{prefix}/share/doc/packages/libstorage/COPYING


### PR DESCRIPTION
…macro (boo#1069468)

Now should build - essential if any libstorage submission wants to be accepted in Factory/SLE 15 as /var/adm/fillup-templates is blacklisted in latest rpmlint - so if this PR doesn't work, I would appreciate an experts view on the package to fix the situation.